### PR TITLE
Fix: Configure frontend API connection for local and Render deployment

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -351,7 +351,13 @@
     </div>
 
     <script>
-        const API_BASE = 'http://localhost:8000';
+        let API_BASE;
+        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+            API_BASE = 'http://localhost:10000';
+        } else {
+            API_BASE = ''; // Use relative path for deployed environment
+        }
+        console.log('API Base URL:', API_BASE);
         let selectedFile = null;
 
         // Función para enviar mensaje al chatbot


### PR DESCRIPTION
The frontend in static/index.html was previously hardcoded to connect to http://localhost:8000.

This change updates the JavaScript to:
- Connect to http://localhost:10000 when running locally (matching the backend port).
- Use a relative path (API_BASE = '') when deployed on Render, as the frontend and backend will be served from the same origin.
- Adds a console.log statement to display the determined API_BASE URL for easier debugging.

This ensures the frontend can communicate with the backend API in both local development and when deployed on Render.